### PR TITLE
Switch to terminal-style palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,13 +1,12 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 :root {
     --header-height: 3rem;
     --font-semi: 600;
 
-    --first-color: #4070F4;
-    --second-color: #0E2431;
+    --first-color: #00ff00;
+    --second-color: #00ff00;
 
-    --body-font: 'Poppins', sans-serif;
+    --body-font: 'Courier New', Courier, monospace;
     --big-font-size: 2rem;
     --h2-font-size: 1.25rem;
     --normal-font-size: .938rem;
@@ -41,6 +40,7 @@ body {
     font-family: var(--body-font);
     font-size: var(--normal-font-size);
     color: var(--second-color);
+    background-color: #000;
 }
 
 h1, h2, p { margin: 0; }
@@ -101,8 +101,8 @@ img {
     top: 0;
     left: 0;
     z-index: var(--z-fixed);
-    background-color: #ffffff;
-    box-shadow: 0 1px 4px rgba(146, 161, 176, .15);
+    background-color: #000;
+    box-shadow: none;
 }
 
 .nav {
@@ -114,7 +114,7 @@ img {
 }
 
 .nav-item { margin-bottom: var(--mb4); }
-.nav-link { position: relative; color: #ffffff; }
+.nav-link { position: relative; color: var(--first-color); }
     .nav-link:hover { position: relative; }
         .nav-link:hover::after {
             position: absolute;
@@ -126,9 +126,9 @@ img {
             background-color: var(--first-color);
         }
 
-.nav-logo { color: var(--second-color); }
+.nav-logo { color: var(--first-color); }
 .nav-toggle {
-    color: var(--second-color);
+    color: var(--first-color);
     font-size: 1.5rem;
     cursor: pointer;
 }
@@ -152,7 +152,7 @@ img {
     width: max-content;
     margin-bottom: var(--mb2);
     font-size: 1.5rem;
-    color: var(--second-color);
+    color: var(--first-color);
     transition: .3s;
 }
 
@@ -174,7 +174,7 @@ img {
 .button {
     display: inline-block;
     background-color: var(--first-color);
-    color: #ffffff;
+    color: #000;
     padding: 0.75rem 2.5rem;
     font-weight: var(--font-semi);
     border-radius: .5rem;
@@ -252,7 +252,7 @@ img {
     font-weight: var(--font-semi);
     padding: 1rem;
     border-radius: .5rem;
-    border: 1px solid var(--second-color);
+    border: 1px solid var(--first-color);
     outline: none;
     margin-bottom: var(--mb4);
 }
@@ -269,8 +269,8 @@ img {
 /*FOOTER*/
 
 .footer {
-    background-color: var(--second-color);
-    color: #ffffff;
+    background-color: #000;
+    color: var(--first-color);
     text-align: center;
     font-weight: var(--font-semi);
     padding: 2rem 0;
@@ -285,7 +285,7 @@ img {
 
 .footer-icon {
     font-size: 1.5rem;
-    color: #ffffff;
+    color: var(--first-color);
     margin: 0 var(--mb2);
 }
 
@@ -301,7 +301,7 @@ img {
     .nav-list { display: flex; padding-top: 0; }
     .nav-item { margin-left: var(--mb6); margin-bottom: 0; }
     .nav-toggle { display: none; }
-    .nav-link { color: var(--second-color); }
+    .nav-link { color: var(--first-color); }
 
     .home { height: 100vh; }
     .home-data { align-self: flex-end; }
@@ -347,7 +347,7 @@ img {
         width: 80%;
         height: 100%;
         padding: 2rem;
-        background-color: var(--second-color);
+        background-color: #000;
         transition: .5s;
     }
 


### PR DESCRIPTION
## Summary
- update color palette to black and green
- use monospace fonts for a terminal look
- tweak header and footer colors

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6886bf5f433c83238ad74bedd9ca2683