### PR TITLE
Move view all work button

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,6 @@
         <section class="work section" id="work">
             <div class="work-header">
                 <h2 class="section-title">Work</h2>
-                <a href="work.html" class="view-all-button" id="view-all-work">View All Work</a>
             </div>
 
             <div class="work-wrapper">
@@ -172,7 +171,7 @@
                 </div>
                 <button class="scroll-arrow right" id="work-right"><i class='bx bx-chevron-right'></i></button>
             </div>
-            <button id="view-all-work" class="view-all-button">View All Work</button>
+            <a href="work.html" class="view-all-button" id="view-all-work">View All Work</a>
         </section>
 
         <section class="contact section" id="contact">

--- a/style.css
+++ b/style.css
@@ -238,7 +238,7 @@ img {
 .work { text-align: center; }
 .work-header {
     text-align: center;
-    margin-bottom: var(--mb2);
+    margin-bottom: var(--mb4);
 }
 
 .work-header .section-title { margin-bottom: 0; }
@@ -263,13 +263,13 @@ img {
     background: none;
     border: none;
     color: var(--first-color);
-    font-size: 2rem;
+    font-size: 3rem;
     cursor: pointer;
     z-index: 1;
 }
 
-.scroll-arrow.left { left: 0; }
-.scroll-arrow.right { right: 0; }
+.scroll-arrow.left { left: var(--mb2); }
+.scroll-arrow.right { right: var(--mb2); }
 
 .work-card {
     flex: 0 0 calc(33.333% - 1rem);
@@ -344,6 +344,8 @@ img {
     .section { padding-top: 4rem; padding-bottom: 3rem; }
     .section-title { margin-bottom: var(--mb6); }
         .section-title::after { width: 80px; top: 3rem; }
+
+    .work-header { margin-bottom: var(--mb6); }
 
     .nav { height: calc(var(--header-height) + 1rem); }
     .nav-list { display: flex; padding-top: 0; }


### PR DESCRIPTION
## Summary
- move the `View All Work` link to the bottom of the work container
- increase spacing after the Work section heading so the scroll menu doesn't stick to it
- move scroll arrows inward and enlarge them for better visibility

## Testing
- `tidy -q -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_6886ce8cdd188323a64cdeb6ad785975