### PR TITLE
Add numbered notepad style code blocks

### DIFF
--- a/project-one.html
+++ b/project-one.html
@@ -37,27 +37,30 @@
                 <h3 class="work-card-title">Introduction</h3>
                 <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
 <div class="code-block">
-<pre><code># Load dataset
-import pandas as pd
-df = pd.read_csv('data.csv')
-</code></pre>
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
 </div>
                 <h3 class="work-card-title">Development</h3>
                 <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
 <div class="code-block">
-<pre><code># Train model
-from sklearn.linear_model import LinearRegression
-model = LinearRegression()
-model.fit(df)
-</code></pre>
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
 </div>
                 <h3 class="work-card-title">Outcome</h3>
                 <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
 <div class="code-block">
-<pre><code># Evaluate results
-score = model.score(df)
-print(score)
-</code></pre>
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
 </div>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -434,8 +434,39 @@ img {
 .blog-container { row-gap: var(--mb4); }
 .blog-container h3 { margin-bottom: var(--mb1); color: var(--first-color); }
 .blog-container p { margin-bottom: var(--mb3); }
-.code-block { background:#1e1e1e; color:#eee; padding:1rem; margin-bottom:var(--mb4); border-radius:0.3rem; font-family:monospace; overflow-x:auto; box-shadow:0 0 10px rgba(0,0,0,0.5); }
-.code-block pre{ margin:0; white-space:pre-wrap; }
+.code-block {
+    background: #1e1e1e;
+    color: #eee;
+    padding: 1rem;
+    margin-bottom: var(--mb4);
+    border-radius: 0.3rem;
+    font-family: 'Courier New', monospace;
+    overflow-x: auto;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.code-block ol {
+    counter-reset: line;
+    margin: 0;
+    padding: 0 0 0 3rem;
+}
+
+.code-block li {
+    list-style: none;
+    white-space: pre;
+    position: relative;
+    padding-left: 0.5rem;
+}
+
+.code-block li::before {
+    counter-increment: line;
+    content: counter(line);
+    position: absolute;
+    left: -2.5rem;
+    color: #ff00ff;
+}
+
+.code-block pre { margin: 0; white-space: pre-wrap; }
 /*MEDIA QUERIES*/
 
 @media screen and (min-width: 769px) {


### PR DESCRIPTION
## Summary
- style project code blocks with fluorescent line numbers
- update project one HTML to use ordered lists for code lines

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c49cec7ac832394a5ae036386e3ce