### PR TITLE
Organize work sections and add project pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,35 +154,35 @@
                     <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
                     <h3 class="work-card-title">Project Two</h3>
                     <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+                    <a href="project-two.html" class="work-card-button">View More</a>
                 </div>
 
                 <div class="work-card">
                     <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
                     <h3 class="work-card-title">Project Three</h3>
                     <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+                    <a href="project-three.html" class="work-card-button">View More</a>
                 </div>
 
                 <div class="work-card">
                     <img src="https://i.postimg.cc/fW1wsSCB/work4.jpg" alt="image">
                     <h3 class="work-card-title">Project Four</h3>
                     <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+                    <a href="project-four.html" class="work-card-button">View More</a>
                 </div>
 
                 <div class="work-card">
                     <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="image">
                     <h3 class="work-card-title">Project Five</h3>
                     <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+                    <a href="project-five.html" class="work-card-button">View More</a>
                 </div>
 
                 <div class="work-card">
                     <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="image">
                     <h3 class="work-card-title">Project Six</h3>
                     <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+                    <a href="project-six.html" class="work-card-button">View More</a>
                 </div>
                 </div>
                 <button class="scroll-arrow right" id="work-right"><i class='bx bx-chevron-right'></i></button>

--- a/main.js
+++ b/main.js
@@ -54,17 +54,21 @@ sr.reveal('.work-card', {interval: 200} )
 sr.reveal('.contact-input', {interval: 200} )
 
 // Work section scroll arrows
-const workContainer = document.querySelector('.work-container');
-const leftArrow = document.getElementById('work-left');
-const rightArrow = document.getElementById('work-right');
+document.querySelectorAll('.work-wrapper').forEach(wrapper => {
+    const container = wrapper.querySelector('.work-container');
+    const left = wrapper.querySelector('.scroll-arrow.left');
+    const right = wrapper.querySelector('.scroll-arrow.right');
 
-if (leftArrow && rightArrow && workContainer) {
-    leftArrow.addEventListener('click', () => {
-        workContainer.scrollBy({left: -workContainer.clientWidth, behavior: 'smooth'});
-    });
+    if (container && left) {
+        left.addEventListener('click', () => {
+            container.scrollBy({ left: -container.clientWidth, behavior: 'smooth' });
+        });
+    }
 
-    rightArrow.addEventListener('click', () => {
-        workContainer.scrollBy({left: workContainer.clientWidth, behavior: 'smooth'});
-    });
-}
+    if (container && right) {
+        right.addEventListener('click', () => {
+            container.scrollBy({ left: container.clientWidth, behavior: 'smooth' });
+        });
+    }
+});
 

--- a/project-five.html
+++ b/project-five.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Five</title>
+    <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav-logo">Chinmay Chalke</a>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-list">
+                    <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
+                    <li class="nav-item"><a href="index.html#about" class="nav-link">About me</a></li>
+                    <li class="nav-item"><a href="index.html#skills" class="nav-link">Skills</a></li>
+                    <li class="nav-item"><a href="index.html#work" class="nav-link active">Work</a></li>
+                    <li class="nav-item"><a href="index.html#contact" class="nav-link">Contact</a></li>
+                </ul>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <i class='bx bx-menu'></i>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="work section">
+            <div class="work-header">
+                <h2 class="section-title">Project Five</h2>
+            </div>
+            <div class="bd-grid blog-container">
+                <h3 class="work-card-title">Introduction</h3>
+                <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Development</h3>
+                <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Outcome</h3>
+                <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
+</div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p class="footer-title">Chinmay Chalke</p>
+        <ul class="social-icons">
+            <li><a href="#"><i class='bx bxl-facebook'></i></a></li>
+            <li><a href="#"><i class='bx bxl-instagram'></i></a></li>
+            <li><a href="#"><i class='bx bxl-twitter'></i></a></li>
+        </ul>
+        <p>&#169; 2025 Copyright all rights reserved</p>
+    </footer>
+
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/project-four.html
+++ b/project-four.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Four</title>
+    <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav-logo">Chinmay Chalke</a>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-list">
+                    <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
+                    <li class="nav-item"><a href="index.html#about" class="nav-link">About me</a></li>
+                    <li class="nav-item"><a href="index.html#skills" class="nav-link">Skills</a></li>
+                    <li class="nav-item"><a href="index.html#work" class="nav-link active">Work</a></li>
+                    <li class="nav-item"><a href="index.html#contact" class="nav-link">Contact</a></li>
+                </ul>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <i class='bx bx-menu'></i>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="work section">
+            <div class="work-header">
+                <h2 class="section-title">Project Four</h2>
+            </div>
+            <div class="bd-grid blog-container">
+                <h3 class="work-card-title">Introduction</h3>
+                <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Development</h3>
+                <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Outcome</h3>
+                <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
+</div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p class="footer-title">Chinmay Chalke</p>
+        <ul class="social-icons">
+            <li><a href="#"><i class='bx bxl-facebook'></i></a></li>
+            <li><a href="#"><i class='bx bxl-instagram'></i></a></li>
+            <li><a href="#"><i class='bx bxl-twitter'></i></a></li>
+        </ul>
+        <p>&#169; 2025 Copyright all rights reserved</p>
+    </footer>
+
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/project-six.html
+++ b/project-six.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Six</title>
+    <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav-logo">Chinmay Chalke</a>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-list">
+                    <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
+                    <li class="nav-item"><a href="index.html#about" class="nav-link">About me</a></li>
+                    <li class="nav-item"><a href="index.html#skills" class="nav-link">Skills</a></li>
+                    <li class="nav-item"><a href="index.html#work" class="nav-link active">Work</a></li>
+                    <li class="nav-item"><a href="index.html#contact" class="nav-link">Contact</a></li>
+                </ul>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <i class='bx bx-menu'></i>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="work section">
+            <div class="work-header">
+                <h2 class="section-title">Project Six</h2>
+            </div>
+            <div class="bd-grid blog-container">
+                <h3 class="work-card-title">Introduction</h3>
+                <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Development</h3>
+                <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Outcome</h3>
+                <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
+</div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p class="footer-title">Chinmay Chalke</p>
+        <ul class="social-icons">
+            <li><a href="#"><i class='bx bxl-facebook'></i></a></li>
+            <li><a href="#"><i class='bx bxl-instagram'></i></a></li>
+            <li><a href="#"><i class='bx bxl-twitter'></i></a></li>
+        </ul>
+        <p>&#169; 2025 Copyright all rights reserved</p>
+    </footer>
+
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/project-three.html
+++ b/project-three.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Three</title>
+    <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav-logo">Chinmay Chalke</a>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-list">
+                    <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
+                    <li class="nav-item"><a href="index.html#about" class="nav-link">About me</a></li>
+                    <li class="nav-item"><a href="index.html#skills" class="nav-link">Skills</a></li>
+                    <li class="nav-item"><a href="index.html#work" class="nav-link active">Work</a></li>
+                    <li class="nav-item"><a href="index.html#contact" class="nav-link">Contact</a></li>
+                </ul>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <i class='bx bx-menu'></i>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="work section">
+            <div class="work-header">
+                <h2 class="section-title">Project Three</h2>
+            </div>
+            <div class="bd-grid blog-container">
+                <h3 class="work-card-title">Introduction</h3>
+                <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Development</h3>
+                <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Outcome</h3>
+                <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
+</div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p class="footer-title">Chinmay Chalke</p>
+        <ul class="social-icons">
+            <li><a href="#"><i class='bx bxl-facebook'></i></a></li>
+            <li><a href="#"><i class='bx bxl-instagram'></i></a></li>
+            <li><a href="#"><i class='bx bxl-twitter'></i></a></li>
+        </ul>
+        <p>&#169; 2025 Copyright all rights reserved</p>
+    </footer>
+
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/project-two.html
+++ b/project-two.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Two</title>
+    <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav-logo">Chinmay Chalke</a>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-list">
+                    <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
+                    <li class="nav-item"><a href="index.html#about" class="nav-link">About me</a></li>
+                    <li class="nav-item"><a href="index.html#skills" class="nav-link">Skills</a></li>
+                    <li class="nav-item"><a href="index.html#work" class="nav-link active">Work</a></li>
+                    <li class="nav-item"><a href="index.html#contact" class="nav-link">Contact</a></li>
+                </ul>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <i class='bx bx-menu'></i>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="work section">
+            <div class="work-header">
+                <h2 class="section-title">Project Two</h2>
+            </div>
+            <div class="bd-grid blog-container">
+                <h3 class="work-card-title">Introduction</h3>
+                <p class="work-card-desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vehicula sapien id sapien consequat, nec faucibus magna fermentum.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Load dataset</code></li>
+        <li><code>import pandas as pd</code></li>
+        <li><code>df = pd.read_csv('data.csv')</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Development</h3>
+                <p class="work-card-desc">Curabitur at lectus eu urna commodo efficitur. Suspendisse potenti. Donec vitae tortor in quam convallis cursus.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Train model</code></li>
+        <li><code>from sklearn.linear_model import LinearRegression</code></li>
+        <li><code>model = LinearRegression()</code></li>
+        <li><code>model.fit(df)</code></li>
+    </ol>
+</div>
+                <h3 class="work-card-title">Outcome</h3>
+                <p class="work-card-desc">Integer ac mauris ut lorem posuere ultrices. Aenean sit amet nulla non erat fringilla porttitor vitae non est.</p>
+<div class="code-block">
+    <ol>
+        <li><code># Evaluate results</code></li>
+        <li><code>score = model.score(df)</code></li>
+        <li><code>print(score)</code></li>
+    </ol>
+</div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p class="footer-title">Chinmay Chalke</p>
+        <ul class="social-icons">
+            <li><a href="#"><i class='bx bxl-facebook'></i></a></li>
+            <li><a href="#"><i class='bx bxl-instagram'></i></a></li>
+            <li><a href="#"><i class='bx bxl-twitter'></i></a></li>
+        </ul>
+        <p>&#169; 2025 Copyright all rights reserved</p>
+    </footer>
+
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/work.html
+++ b/work.html
@@ -31,72 +31,82 @@
     <main class="l-main">
         <section class="work section">
             <h2 class="section-title">Work Section One</h2>
-            <div class="work-container bd-grid">
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
-                    <h3 class="work-card-title">Project One</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-one.html" class="work-card-button">View More</a>
+            <div class="work-wrapper">
+                <button class="scroll-arrow left"><i class='bx bx-chevron-left'></i></button>
+                <div class="work-container bd-grid">
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
+                        <h3 class="work-card-title">Project One</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-one.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
+                        <h3 class="work-card-title">Project Two</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-two.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
+                        <h3 class="work-card-title">Project Three</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-three.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                        <h3 class="work-card-title">Upcoming</h3>
+                        <p class="work-card-desc">Stay tuned for more.</p>
+                        <span class="work-card-button">Coming Soon</span>
+                    </div>
                 </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
-                    <h3 class="work-card-title">Project Two</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
-                    <h3 class="work-card-title">Project Three</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
+                <button class="scroll-arrow right"><i class='bx bx-chevron-right'></i></button>
             </div>
         </section>
 
         <section class="work section">
             <h2 class="section-title">Work Section Two</h2>
-            <div class="work-container bd-grid">
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/fW1wsSCB/work4.jpg" alt="image">
-                    <h3 class="work-card-title">Project Four</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+            <div class="work-wrapper">
+                <button class="scroll-arrow left"><i class='bx bx-chevron-left'></i></button>
+                <div class="work-container bd-grid">
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/fW1wsSCB/work4.jpg" alt="image">
+                        <h3 class="work-card-title">Project Four</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-four.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="image">
+                        <h3 class="work-card-title">Project Five</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-five.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="image">
+                        <h3 class="work-card-title">Project Six</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-six.html" class="work-card-button">View More</a>
+                    </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                        <h3 class="work-card-title">Upcoming</h3>
+                        <p class="work-card-desc">Stay tuned for more.</p>
+                        <span class="work-card-button">Coming Soon</span>
+                    </div>
                 </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="image">
-                    <h3 class="work-card-title">Project Five</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="image">
-                    <h3 class="work-card-title">Project Six</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
+                <button class="scroll-arrow right"><i class='bx bx-chevron-right'></i></button>
             </div>
         </section>
 
         <section class="work section">
             <h2 class="section-title">Work Section Three</h2>
-            <div class="work-container bd-grid">
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
-                    <h3 class="work-card-title">Project Seven</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
-                    <h3 class="work-card-title">Project Eight</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
-                </div>
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
-                    <h3 class="work-card-title">Project Nine</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="#" class="work-card-button">View More</a>
+            <div class="work-wrapper">
+                <div class="work-container bd-grid">
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                        <h3 class="work-card-title">Upcoming</h3>
+                        <p class="work-card-desc">Stay tuned for more.</p>
+                        <span class="work-card-button">Coming Soon</span>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- Add blog-style pages for Projects Two through Six.
- Link index work cards to each project page.
- Rework work.html into scrollable sections with upcoming placeholders and generic JS scroll handling.
- Remove scroll arrows from third work section with only an upcoming card.
- Replace placeholder images on upcoming cards with a project photo.

## Testing
- `node --check main.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68917b81cabc83238c434b2f0e160d2c