### PR TITLE
Align code snippets to the left

### DIFF
--- a/style.css
+++ b/style.css
@@ -446,29 +446,19 @@ img {
 }
 
 .code-block ol {
-    counter-reset: line;
     margin: 0;
-    padding: 0;
+    padding-left: 1.2rem;
 }
 
 .code-block li {
-    list-style: none;
+    list-style-type: decimal;
+    list-style-position: inside;
     white-space: pre;
-    position: relative;
-    padding-left: 3rem;
     line-height: 1.5;
-    display: block;
 }
 
 .code-block li::before {
-    counter-increment: line;
-    content: counter(line) ".";
-    position: absolute;
-    left: 0;
-    width: 2.5rem;
-    text-align: right;
-    padding-right: 0.5rem;
-    color: #ff00ff;
+    content: none;
 }
 
 .code-block pre { margin: 0; white-space: pre-wrap; }


### PR DESCRIPTION
## Summary
- Remove custom list counters and left padding from code blocks
- Use standard decimal list styling for numbered snippets

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_689181e8757c83238e71db707036891a