### PR TITLE
fix: show all projects on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,9 +140,7 @@
                 <h2 class="section-title">Work</h2>
             </div>
 
-            <div class="work-wrapper">
-                <button class="scroll-arrow left" id="work-left"><i class='bx bx-chevron-left'></i></button>
-                <div class="work-container bd-grid">
+            <div class="work-container bd-grid">
                 <div class="work-card">
                     <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
                     <h3 class="work-card-title">Project One</h3>
@@ -171,21 +169,33 @@
                     <a href="project-four.html" class="work-card-button">View More</a>
                 </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="image">
+                <div class="work-card" id="project-five">
+                    <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="Project Five screenshot">
                     <h3 class="work-card-title">Project Five</h3>
                     <p class="work-card-desc">Short description of the project.</p>
                     <a href="project-five.html" class="work-card-button">View More</a>
                 </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="image">
+                <div class="work-card" id="project-six">
+                    <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="Project Six screenshot">
                     <h3 class="work-card-title">Project Six</h3>
                     <p class="work-card-desc">Short description of the project.</p>
                     <a href="project-six.html" class="work-card-button">View More</a>
                 </div>
+
+                <div class="work-card">
+                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                    <h3 class="work-card-title">Upcoming</h3>
+                    <p class="work-card-desc">Stay tuned for more.</p>
+                    <span class="work-card-button">Coming Soon</span>
                 </div>
-                <button class="scroll-arrow right" id="work-right"><i class='bx bx-chevron-right'></i></button>
+
+                <div class="work-card">
+                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                    <h3 class="work-card-title">Upcoming</h3>
+                    <p class="work-card-desc">Stay tuned for more.</p>
+                    <span class="work-card-button">Coming Soon</span>
+                </div>
             </div>
             <a href="work.html" class="view-all-button" id="view-all-work">View All Work</a>
         </section>

--- a/style.css
+++ b/style.css
@@ -259,15 +259,10 @@ img {
 .work-header .section-title { margin-bottom: 0; }
 .work-container {
     display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
+    flex-wrap: wrap;
     gap: 1rem;
-    scroll-snap-type: x mandatory;
     padding-bottom: 1rem;
-    scrollbar-width: none;
 }
-
-    .work-container::-webkit-scrollbar { display: none; }
 
 .work-wrapper { position: relative; }
 


### PR DESCRIPTION
## Summary
- display all six projects with two upcoming placeholders on the home page
- allow work cards to wrap so every project is visible without scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689187ef29408323b78351c2167ae31f