### PR TITLE
Restore scrollable Work section with arrow navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,62 +140,66 @@
                 <h2 class="section-title">Work</h2>
             </div>
 
-            <div class="work-container bd-grid">
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
-                    <h3 class="work-card-title">Project One</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-one.html" class="work-card-button">View More</a>
-                </div>
+            <div class="work-wrapper">
+                <button class="scroll-arrow left"><i class='bx bx-chevron-left'></i></button>
+                <div class="work-container bd-grid">
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="image">
+                        <h3 class="work-card-title">Project One</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-one.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
-                    <h3 class="work-card-title">Project Two</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-two.html" class="work-card-button">View More</a>
-                </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/tJZmDTVg/work2.jpg" alt="image">
+                        <h3 class="work-card-title">Project Two</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-two.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
-                    <h3 class="work-card-title">Project Three</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-three.html" class="work-card-button">View More</a>
-                </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image">
+                        <h3 class="work-card-title">Project Three</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-three.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/fW1wsSCB/work4.jpg" alt="image">
-                    <h3 class="work-card-title">Project Four</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-four.html" class="work-card-button">View More</a>
-                </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/fW1wsSCB/work4.jpg" alt="image">
+                        <h3 class="work-card-title">Project Four</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-four.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card" id="project-five">
-                    <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="Project Five screenshot">
-                    <h3 class="work-card-title">Project Five</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-five.html" class="work-card-button">View More</a>
-                </div>
+                    <div class="work-card" id="project-five">
+                        <img src="https://i.postimg.cc/m2MTgZ6R/work5.jpg" alt="Project Five screenshot">
+                        <h3 class="work-card-title">Project Five</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-five.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card" id="project-six">
-                    <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="Project Six screenshot">
-                    <h3 class="work-card-title">Project Six</h3>
-                    <p class="work-card-desc">Short description of the project.</p>
-                    <a href="project-six.html" class="work-card-button">View More</a>
-                </div>
+                    <div class="work-card" id="project-six">
+                        <img src="https://i.postimg.cc/Qd3h9LR7/work6.jpg" alt="Project Six screenshot">
+                        <h3 class="work-card-title">Project Six</h3>
+                        <p class="work-card-desc">Short description of the project.</p>
+                        <a href="project-six.html" class="work-card-button">View More</a>
+                    </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
-                    <h3 class="work-card-title">Upcoming</h3>
-                    <p class="work-card-desc">Stay tuned for more.</p>
-                    <span class="work-card-button">Coming Soon</span>
-                </div>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                        <h3 class="work-card-title">Upcoming</h3>
+                        <p class="work-card-desc">Stay tuned for more.</p>
+                        <span class="work-card-button">Coming Soon</span>
+                    </div>
 
-                <div class="work-card">
-                    <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
-                    <h3 class="work-card-title">Upcoming</h3>
-                    <p class="work-card-desc">Stay tuned for more.</p>
-                    <span class="work-card-button">Coming Soon</span>
+                    <div class="work-card">
+                        <img src="https://i.postimg.cc/NM0n9bsm/work1.jpg" alt="Upcoming project">
+                        <h3 class="work-card-title">Upcoming</h3>
+                        <p class="work-card-desc">Stay tuned for more.</p>
+                        <span class="work-card-button">Coming Soon</span>
+                    </div>
                 </div>
+                <button class="scroll-arrow right"><i class='bx bx-chevron-right'></i></button>
             </div>
             <a href="work.html" class="view-all-button" id="view-all-work">View All Work</a>
         </section>

--- a/style.css
+++ b/style.css
@@ -259,9 +259,17 @@ img {
 .work-header .section-title { margin-bottom: 0; }
 .work-container {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 1rem;
     padding-bottom: 1rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+}
+
+.work-container::-webkit-scrollbar {
+    display: none;
 }
 
 .work-wrapper { position: relative; }


### PR DESCRIPTION
## Summary
- Wrap Work section cards with a `work-wrapper` and add left/right arrow buttons.
- Update CSS to enable horizontal scrolling, snapping, and hide native scrollbars.

## Testing
- `npm test` *(fails: ENOENT no package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689547b2cce483238897822cc9a9c019