### PR TITLE
Restructure skills section with categorized progress bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,58 +74,89 @@
             <div class="skills-container bd-grid">
                 <div>
                     <h2 class="skills-subtitle">Professional Skills</h2>
-                    <p class="skills-text">I love to think outside the box and bring unique ideas to life through design, I have proficiency in HTML, CSS, and JavaScript, that ensure that my designs are not only beautiful but also functional. I prioritize the needs and preferences of users, conducting research to understand their behaviors and preferences.</p>
+                    <p class="skills-text">I love crafting smart systems that not only work well but think for themselves. With a strong foundation in Python, I build robust backends, train machine learning models, and automate real-world processes that drive impact. My experience with tools like NumPy, Pandas, scikit-learn, and PyTorch helps me bring AI concepts to life in clean, reliable code.<br><br>
+                    Cloud platforms like Azure and IBM Cloud allow me to scale and deploy solutions with confidence, while SQL and data warehousing knowledge ensures the backend has strong data foundations.<br><br>
+                    I also enjoy the creative side of tech — translating logic into clean UI. With HTML, CSS, JavaScript, and Bootstrap, I’ve designed responsive interfaces that make the user experience smooth and intuitive. Whether I’m fine-tuning a model or styling a page, I care about building systems that are functional, user-centered, and purpose-driven.</p>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-html5 skills-icon' ></i>
-                            <span class="skills-name">HTML5</span>
+                    <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">⚙️ Backend Development</span>
+                            </div>
+
+                            <div>
+                                <span class="skills-percentage">95%</span>
+                            </div>
+
+                            <div class="skills-bar skills-backend"></div>
                         </div>
-
-                        <div>
-                            <span class="skills-percentage">95%</span>
-                        </div>
-
-                        <div class="skills-bar skills-html"></div>
+                        <p class="skills-bullets">
+                            Python (3+ years)<br>
+                            RESTful APIs &amp; automation scripts<br>
+                            Backend architecture &amp; logic flow<br>
+                            Real-time bot and system integrations<br>
+                            Cloud deployment using Azure and IBM Cloud
+                        </p>
                     </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-css3 skills-icon' ></i>
-                            <span class="skills-name">CSS3</span>
-                        </div>
+                    <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🤖 Machine Learning / AI</span>
+                            </div>
 
-                        <div>
-                            <span class="skills-percentage">85%</span>
-                        </div>
+                            <div>
+                                <span class="skills-percentage">90%</span>
+                            </div>
 
-                        <div class="skills-bar skills-css"></div>
+                            <div class="skills-bar skills-ml"></div>
+                        </div>
+                        <p class="skills-bullets">
+                            Python ML libraries: NumPy, Pandas, scikit-learn<br>
+                            Deep learning with PyTorch<br>
+                            Data pre-processing, feature engineering, model tuning<br>
+                            End-to-end ML pipelines (train → validate → deploy)
+                        </p>
                     </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-javascript skills-icon' ></i>
-                            <span class="skills-name">JAVASCRIPT</span>
-                        </div>
+                    <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🗃️ Data &amp; Databases</span>
+                            </div>
 
-                        <div>
-                            <span class="skills-percentage">65%</span>
-                        </div>
+                            <div>
+                                <span class="skills-percentage">85%</span>
+                            </div>
 
-                        <div class="skills-bar skills-js"></div>
+                            <div class="skills-bar skills-database"></div>
+                        </div>
+                        <p class="skills-bullets">
+                            SQL (queries, joins, aggregation, performance tuning)<br>
+                            Data warehousing concepts<br>
+                            Structured data pipelines and integration<br>
+                            Clean data extraction and transformation for ML readiness
+                        </p>
                     </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxs-paint skills-icon' ></i>
-                            <span class="skills-name">UX/UI</span>
-                        </div>
+                    <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🎨 Frontend / UI Development</span>
+                            </div>
 
-                        <div>
-                            <span class="skills-percentage">85%</span>
-                        </div>
+                            <div>
+                                <span class="skills-percentage">80%</span>
+                            </div>
 
-                        <div class="skills-bar skills-ux"></div>
+                            <div class="skills-bar skills-frontend"></div>
+                        </div>
+                        <p class="skills-bullets">
+                            HTML, CSS, JavaScript, Bootstrap<br>
+                            Responsive, mobile-first design<br>
+                            UI/UX awareness for intuitive interfaces<br>
+                            Built full-stack prototypes with frontend &amp; backend integration
+                        </p>
                     </div>
                 </div>
 

--- a/style.css
+++ b/style.css
@@ -242,10 +242,15 @@ img {
     z-index: var(--z-back);
 }
 
-.skills-html { width: 95%; }
-.skills-css { width: 85%; }
-.skills-js { width: 65%; }
-.skills-ux { width: 85%; }
+.skills-backend { width: 95%; }
+.skills-ml { width: 90%; }
+.skills-database { width: 85%; }
+.skills-frontend { width: 80%; }
+.skills-bullets {
+    text-align: left;
+    margin-bottom: var(--mb4);
+    line-height: 1.6;
+}
 .skills-img { border-radius: .5rem; }
 
 /*WORK*/


### PR DESCRIPTION
## Summary
- Organize Skills section into backend, machine learning, data, and frontend groups with bullet highlights and progress bars
- Add supporting CSS for new skill categories and bullet styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895535f1efc83239497d44d76623c73