### PR TITLE
Streamline skills section to progress bars only

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,66 +72,83 @@
             <h2 class="section-title">Skills</h2>
 
             <div class="skills-container bd-grid">
-                <div>
-                    <h2 class="skills-subtitle">Professional Skills</h2>
-                    <p class="skills-text">I love to think outside the box and bring unique ideas to life through design, I have proficiency in HTML, CSS, and JavaScript, that ensure that my designs are not only beautiful but also functional. I prioritize the needs and preferences of users, conducting research to understand their behaviors and preferences.</p>
-
+                <div class="skills-block">
                     <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-html5 skills-icon' ></i>
-                            <span class="skills-name">HTML5</span>
-                        </div>
+                            <div class="skills-names">
+                                <span class="skills-name">⚙️ Backend Development</span>
+                            </div>
 
-                        <div>
-                            <span class="skills-percentage">95%</span>
-                        </div>
+                            <div>
+                                <span class="skills-percentage">95%</span>
+                            </div>
 
-                        <div class="skills-bar skills-html"></div>
+                            <div class="skills-bar skills-backend"></div>
+                        </div>
+                        <p class="skills-bullets">
+                            Python (3+ years)<br>
+                            RESTful APIs &amp; automation scripts<br>
+                            Backend architecture &amp; logic flow<br>
+                            Real-time bot and system integrations<br>
+                            Cloud deployment using Azure and IBM Cloud
+                        </p>
                     </div>
+                <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🤖 Machine Learning / AI</span>
+                            </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-css3 skills-icon' ></i>
-                            <span class="skills-name">CSS3</span>
+                            <div>
+                                <span class="skills-percentage">90%</span>
+                            </div>
+
+                            <div class="skills-bar skills-ml"></div>
                         </div>
-
-                        <div>
-                            <span class="skills-percentage">85%</span>
-                        </div>
-
-                        <div class="skills-bar skills-css"></div>
+                        <p class="skills-bullets">
+                            Python ML libraries: NumPy, Pandas, scikit-learn<br>
+                            Deep learning with PyTorch<br>
+                            Data pre-processing, feature engineering, model tuning<br>
+                            End-to-end ML pipelines (train → validate → deploy)
+                        </p>
                     </div>
+                <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🗃️ Data &amp; Databases</span>
+                            </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxl-javascript skills-icon' ></i>
-                            <span class="skills-name">JAVASCRIPT</span>
+                            <div>
+                                <span class="skills-percentage">85%</span>
+                            </div>
+
+                            <div class="skills-bar skills-database"></div>
                         </div>
-
-                        <div>
-                            <span class="skills-percentage">65%</span>
-                        </div>
-
-                        <div class="skills-bar skills-js"></div>
+                        <p class="skills-bullets">
+                            SQL (queries, joins, aggregation, performance tuning)<br>
+                            Data warehousing concepts<br>
+                            Structured data pipelines and integration<br>
+                            Clean data extraction and transformation for ML readiness
+                        </p>
                     </div>
+                <div class="skills-block">
+                        <div class="skills-data">
+                            <div class="skills-names">
+                                <span class="skills-name">🎨 Frontend / UI Development</span>
+                            </div>
 
-                    <div class="skills-data">
-                        <div class="skills-names">
-                            <i class='bx bxs-paint skills-icon' ></i>
-                            <span class="skills-name">UX/UI</span>
+                            <div>
+                                <span class="skills-percentage">80%</span>
+                            </div>
+
+                            <div class="skills-bar skills-frontend"></div>
                         </div>
-
-                        <div>
-                            <span class="skills-percentage">85%</span>
-                        </div>
-
-                        <div class="skills-bar skills-ux"></div>
+                        <p class="skills-bullets">
+                            HTML, CSS, JavaScript, Bootstrap<br>
+                            Responsive, mobile-first design<br>
+                            UI/UX awareness for intuitive interfaces<br>
+                            Built full-stack prototypes with frontend &amp; backend integration
+                        </p>
                     </div>
-                </div>
-
-                <div>
-                    <img src="https://i.postimg.cc/52LWbPyt/work3.jpg" alt="image" class="skills-img">
-                </div>
             </div>
         </section>
 

--- a/main.js
+++ b/main.js
@@ -44,10 +44,7 @@ sr.reveal('.about-img', {} )
 sr.reveal('.about-subtitle', {delay: 200} )
 sr.reveal('.about-text', {delay: 400} )
 
-sr.reveal('.skills-subtitle', {delay: 100} )
-sr.reveal('.skills-text', {delay: 150} )
 sr.reveal('.skills-data', {interval: 200} )
-sr.reveal('.skills-img', {delay: 400} )
 
 sr.reveal('.work-card', {interval: 200} )
 

--- a/style.css
+++ b/style.css
@@ -207,8 +207,6 @@ img {
 /*SKILLS*/
 
 .skills-container { row-gap: 2rem; text-align: center; }
-.skills-subtitle { margin-bottom: var(--mb2); }
-.skills-text { margin-bottom: var(--mb4); }
 .skills-data {
     display: flex;
     justify-content: space-between;
@@ -242,11 +240,15 @@ img {
     z-index: var(--z-back);
 }
 
-.skills-html { width: 95%; }
-.skills-css { width: 85%; }
-.skills-js { width: 65%; }
-.skills-ux { width: 85%; }
-.skills-img { border-radius: .5rem; }
+.skills-backend { width: 95%; }
+.skills-ml { width: 90%; }
+.skills-database { width: 85%; }
+.skills-frontend { width: 80%; }
+.skills-bullets {
+    text-align: left;
+    margin-bottom: var(--mb4);
+    line-height: 1.6;
+}
 
 /*WORK*/
 
@@ -495,9 +497,15 @@ img {
     .home-social-icon { margin-bottom: 0; margin-right: var(--mb4); }
     .home-img { width: 457px; height: 475px; bottom: 15%; }
 
-    .about-container, .skills-container {
+    .about-container {
         grid-template-columns: repeat(2, 1fr);
         align-items: center;
+        text-align: initial;
+    }
+
+    .skills-container {
+        grid-template-columns: repeat(2, 1fr);
+        align-items: flex-start;
         text-align: initial;
     }
 


### PR DESCRIPTION
## Summary
- Drop image from skills section and reflow four skill blocks directly inside container
- Arrange skills into a two-column layout on larger screens and remove unused ScrollReveal hook and styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895535f1efc83239497d44d76623c73